### PR TITLE
Add missing header directives

### DIFF
--- a/src/anm2/anm2_sounds.cpp
+++ b/src/anm2/anm2_sounds.cpp
@@ -4,6 +4,8 @@
 #include "path_.h"
 #include "working_directory.h"
 
+#include <format>
+
 using namespace anm2ed::types;
 using namespace anm2ed::util;
 using namespace tinyxml2;

--- a/src/imgui/toast.cpp
+++ b/src/imgui/toast.cpp
@@ -5,6 +5,8 @@
 
 #include "types.h"
 
+#include <format>
+
 using namespace anm2ed::types;
 
 namespace anm2ed::imgui

--- a/src/imgui/window/events.cpp
+++ b/src/imgui/window/events.cpp
@@ -1,6 +1,7 @@
 #include "events.h"
 
 #include <ranges>
+#include <format>
 
 #include "log.h"
 #include "map_.h"

--- a/src/imgui/window/layers.cpp
+++ b/src/imgui/window/layers.cpp
@@ -1,6 +1,7 @@
 #include "layers.h"
 
 #include <ranges>
+#include <format>
 
 #include "log.h"
 #include "map_.h"

--- a/src/imgui/window/nulls.cpp
+++ b/src/imgui/window/nulls.cpp
@@ -1,6 +1,7 @@
 #include "nulls.h"
 
 #include <ranges>
+#include <format>
 
 #include "log.h"
 #include "map_.h"

--- a/src/imgui/window/sounds.cpp
+++ b/src/imgui/window/sounds.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <ranges>
 #include <vector>
+#include <format>
 
 #include "log.h"
 #include "path_.h"

--- a/src/imgui/window/timeline.cpp
+++ b/src/imgui/window/timeline.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <format>
 
 #include <imgui_internal.h>
 

--- a/src/imgui/window/welcome.cpp
+++ b/src/imgui/window/welcome.cpp
@@ -1,6 +1,7 @@
 #include "welcome.h"
 
 #include <ranges>
+#include <format>
 
 #include "path_.h"
 #include "strings.h"

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -3,6 +3,7 @@
 #include <cerrno>
 #include <cstdint>
 #include <filesystem>
+#include <format>
 
 #include <imgui/backends/imgui_impl_opengl3.h>
 #include <imgui/backends/imgui_impl_sdl3.h>
@@ -22,7 +23,6 @@
 #ifdef _WIN32
   #include "util/path_.h"
   #include <DbgHelp.h>
-  #include <format>
   #include <windows.h>
 #endif
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,6 +1,7 @@
 #include "log.h"
 
 #include <print>
+#include <format>
 
 #include "sdl.h"
 #include "time_.h"


### PR DESCRIPTION
I've noticed that compiling this software using gcc seems to throw errors with `std::format` or `std::vformat` not existing, so I threw in the missing header directives and it seemed to compile without a hitch!